### PR TITLE
server-side 훅을 구현한다.

### DIFF
--- a/client/src/api/client/axiosInterceptors.ts
+++ b/client/src/api/client/axiosInterceptors.ts
@@ -17,8 +17,6 @@ axiosInstance.interceptors.request.use(
     const TOKEN: string = process.env.NEXT_PUBLIC_MY_ANON_KEY || "";
     // const token = localStorage.getItem("token") || TOKEN;
     // const token = TOKEN;
-
-    console.log("🚀 Authorization header:", TOKEN);
     if (TOKEN) {
       config.headers.Authorization = `Bearer ${TOKEN}`;
     }

--- a/client/src/app/clientTest/page.tsx
+++ b/client/src/app/clientTest/page.tsx
@@ -3,8 +3,7 @@
 import { useFetch } from "@/hook";
 import { get } from "@/api";
 import { LedgerModel } from "@/types";
-import "@/api/client/axiosInterceptors";
-// import { useEffect } from "react";
+import { useEffect } from "react";
 
 const Test = (): React.ReactNode => {
   /**client-side 호출 */
@@ -13,24 +12,10 @@ const Test = (): React.ReactNode => {
     "https://jsonplaceholder.typicode.com/posts";
   const { isData } = useFetch<LedgerModel[]>(() => get(`${URL}`), true);
 
-  console.log(isData);
+  useEffect(() => {
+    console.log(isData);
+  }, [isData]);
 
-  /**server-side 호출 */
-  // const fetchLedger = async (): Promise<void> => {
-  //   try {
-  //     const res = await fetch("/api/ledger/get"); // ✅ Next API Route 호출
-  //     if (!res.ok) throw new Error("서버 응답 실패");
-
-  //     const data = await res.json();
-  //     console.log("Ledger:", data);
-  //   } catch (error) {
-  //     console.error("Ledger 불러오기 실패:", error);
-  //   }
-  // };
-  // useEffect(() => {
-  //   fetchLedger();
-  // }, []);
-  /**--- */
   return <div>Test</div>;
 };
 

--- a/client/src/app/serverTest/page.tsx
+++ b/client/src/app/serverTest/page.tsx
@@ -1,24 +1,20 @@
 "use client";
 
-// import "@/api/client/axiosInterceptors";
+import { useFetch } from "@/hook";
+import { get } from "@/api";
+import { LedgerModel } from "@/types";
 import { useEffect } from "react";
 
 const Test = (): React.ReactNode => {
   /**server-side 호출 */
-  const fetchLedger = async (): Promise<void> => {
-    try {
-      const res = await fetch("/api/ledger/get"); // ✅ Next API Route 호출
-      if (!res.ok) throw new Error("서버 응답 실패");
-
-      const data = await res.json();
-      console.log("Ledger:", data);
-    } catch (error) {
-      console.error("Ledger 불러오기 실패:", error);
-    }
-  };
+  const { isData } = useFetch<LedgerModel[]>(
+    () => get("/api/ledger/get"),
+    true
+  );
   useEffect(() => {
-    fetchLedger();
-  }, []);
+    console.log(isData);
+  }, [isData]);
+
   return <div>Test</div>;
 };
 

--- a/client/src/hook/useFetch.tsx
+++ b/client/src/hook/useFetch.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useEffect, useState } from "react";
 
 const useFetch = (


### PR DESCRIPTION
# Goal
- [x] server-side fetching을 위한 훅을 구현한다.

# axiosInstanceServer
useFetch 훅을 server 전용 훅을 구현하려고 했으나 이는 불필요한 방식이라 판단했다. 이유는 `src/api/server/axiosInstanceServer`는 server-side를 위한 instance이다. 즉, `pages/api/~`를 위한 코드이다. 따라서 착각하면 안되는 것이 axiosinstanceServer는 client에서 사용되는 axios가 아니다. 

# 디렉토리 구조의 재성찰
다시 보아도 `src/api` 디렉토리 구조는 매우 불합리적이다. 더불어서 `axiosInstanceServer`와 `axiosInstance`를 `sever`와 `client` 둘로 두고 관리하는 것이 관연 생산적이고 효율적인지 잘 모르겠다.