### PR TITLE
다중 결제/다중 상품 등록 UI를 구현한다.

### DIFF
--- a/client/src/api/client/axiosInterceptors.ts
+++ b/client/src/api/client/axiosInterceptors.ts
@@ -42,7 +42,7 @@ axiosInstance.interceptors.request.use(
 axiosInstance.interceptors.response.use(
   (response: AxiosResponse) => {
     /**응답 데이터 변환: 현재는 불필요 */
-    console.log("check response");
+    // console.log("check response");
     if (response.data) {
       response.data = transformResponseData(response.data);
     }

--- a/client/src/api/transformers.ts
+++ b/client/src/api/transformers.ts
@@ -1,13 +1,15 @@
 import { RequestData, ResponseData } from "@/types";
 /** 요청으로 부터 받은 데이터 형태 변화 함수 */
-export const transformRequestData = (data: RequestData): RequestData => {
+export const transformRequestData = (
+  data: RequestData | RequestData[]
+): RequestData | RequestData[] => {
   // console.log("check data", data);
   //배열인 경우 재귀적으로 호출
   if (Array.isArray(data)) {
     // console.log("check data is array!!", data);
     return data.map((item) => {
       // console.log("check item", data);
-      return transformRequestData(item);
+      return transformRequestData(item) as RequestData;
     });
   }
   // 요청 데이터 변환 로직
@@ -24,11 +26,12 @@ export const transformRequestData = (data: RequestData): RequestData => {
   return snakeCaseData;
 };
 
+// 응답 데이터를 error를 포함하기 때문에 data와 error를 포함하는 객체로 받는다.
 export const transformResponseData = (response: {
   data: ResponseData | ResponseData[];
-  error: unknown;
-}): { data: ResponseData | ResponseData[]; error: unknown } => {
-  console.log("check response", response);
+  error: string | null;
+}): { data: ResponseData | ResponseData[]; error: string | null } => {
+  console.log("🎯check response", response);
   // 응답 데이터 변환 로직
   if (!response.data) return response;
 

--- a/client/src/api/transformers.ts
+++ b/client/src/api/transformers.ts
@@ -1,16 +1,26 @@
 import { RequestData, ResponseData } from "@/types";
 /** 요청으로 부터 받은 데이터 형태 변화 함수 */
 export const transformRequestData = (data: RequestData): RequestData => {
+  // console.log("check data", data);
+  //배열인 경우 재귀적으로 호출
+  if (Array.isArray(data)) {
+    // console.log("check data is array!!", data);
+    return data.map((item) => {
+      // console.log("check item", data);
+      return transformRequestData(item);
+    });
+  }
   // 요청 데이터 변환 로직
   const snakeCaseData: RequestData = {};
+  // 예외처리가 매우 필요하다.
   for (const key in data) {
-    console.log("check key", key);
+    // console.log("check key", key);
     if (Object.prototype.hasOwnProperty.call(data, key)) {
       const snakeKey = key.replace(/([A-Z])/g, "_$1").toLowerCase();
       snakeCaseData[snakeKey] = data[key];
     }
   }
-  console.log("check snakeCaseData", snakeCaseData);
+  // console.log("check snakeCaseData", JSON.stringify(snakeCaseData, null, 2));
   return snakeCaseData;
 };
 
@@ -18,6 +28,7 @@ export const transformResponseData = (response: {
   data: ResponseData | ResponseData[];
   error: unknown;
 }): { data: ResponseData | ResponseData[]; error: unknown } => {
+  console.log("check response", response);
   // 응답 데이터 변환 로직
   if (!response.data) return response;
 

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -13,7 +13,10 @@ import {
   LedgerDataResponse,
   LedgerModel,
   LedgerRequire,
+  PaymentModel,
+  PaymentDataResponse,
   PaymentRequire,
+  FormRequire,
 } from "@/types";
 import { HeaderRow, DataRow } from "@/components";
 import { useFetch, useMutation } from "@/hook";
@@ -119,7 +122,7 @@ export default function Home(): ReactElement {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<LedgerRequire>();
+  } = useForm<FormRequire>();
 
   const [isTax, setTax] = useState<boolean>(false);
 

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -123,7 +123,7 @@ export default function Home(): ReactElement {
     handle((prev) => !prev);
   };
 
-  const onSubmit = async (data: LedgerRequire): Promise<void> => {
+  const onSubmit = async (data: FormRequire): Promise<void> => {
     try {
       const costPrice = data.costPrice * data.count;
       const salePrice = data.salePrice * data.count;

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -91,26 +91,6 @@ export default function Home(): ReactElement {
     post<PaymentDataResponse, PaymentRequire[]>("/api/payment/post", payload)
   );
 
-  // new Map을 사용해서 코드 간결화 필요.
-  const testPayment = async (): Promise<void> => {
-    const payload: PaymentRequire[] = [
-      {
-        ledgerId: 50,
-        type: "card",
-        price: 9000,
-        profit: 6300,
-      },
-      {
-        ledgerId: 50,
-        type: "cash",
-        price: 9000,
-        profit: 6300,
-      },
-    ];
-    const result = await paymentPostMutate(payload);
-    console.log("🎯result", result);
-  };
-
   const [isDateSlideOpen, setDateSlideOpen] = useState<boolean>(false);
   const [isHeaderActive, setHeaderActive] = useState<boolean>(false);
   const [isComplexPayment, setComplexPayment] = useState<boolean>(false);
@@ -167,18 +147,31 @@ export default function Home(): ReactElement {
       // 데이터에 required에 맞는 필드 추가 필요.
       // const result = await post("api/ledger/post", payload);
       // const result = await post("api/ledger/post", payload);
-      await postMutate(payload);
-
+      const ledgerResult = await postMutate(payload);
+      console.log("🎯ledgerResult", ledgerResult.data[0].id);
+      const ledgerId = ledgerResult.data[0].id;
       // 2. Payment 요청 준비
-      // const paymentPayload: PaymentUnit = {
-      //   ledger_id: 50,
-      //   type: "card",
-      //   price: 9000,
-      //   profit: 6300,
-      // };
+      if (!ledgerResult || !ledgerId) {
+        throw new Error("다중 결제 등록 실패");
+      }
+
+      const paymentPayload: PaymentRequire[] = [
+        {
+          ledgerId,
+          type: "card",
+          price: Number(data.cardPrice),
+          profit: 6300,
+        },
+        {
+          ledgerId,
+          type: "cash",
+          price: Number(data.cashPrice),
+          profit: 6300,
+        },
+      ];
       // if (data.cardPrice) {
-      //   paymentPayload.pu✅sh({
-      //     ledger_id: 46,
+      //   paymentPayload.push({
+      //     ledgerId: 46,
       //     type: "card",
       //     price: Number(data.cardPrice),
       //     profit: 100,
@@ -187,15 +180,15 @@ export default function Home(): ReactElement {
 
       // if (data.cashPrice) {
       //   paymentPayload.push({
-      //     ledger_id: 46,
+      //     ledgerId: 46,
       //     type: "cash",
       //     price: Number(data.cashPrice),
       //     profit: 100,
       //   });
       // }
-      // console.log("🎯paymentPayload", paymentPayload);
-      // const result = await paymentPostMutate(paymentPayload);
-      // console.log("🎯result", result);
+      console.log("🎯paymentPayload", paymentPayload);
+      const paymentResult = await paymentPostMutate(paymentPayload);
+      console.log("🎯paymentResult", paymentResult);
 
       await fetchData();
       await paymentFetchData();
@@ -276,7 +269,7 @@ export default function Home(): ReactElement {
   return (
     // 여기서 h-screen은 매번 기입을 해야하는건가?
     <div className="h-screen flex flex-col items-center justify-center">
-      <button onClick={testPayment}>testPayment</button>
+      {/* <button onClick={testPayment}>testPayment</button> */}
       <div className="flex w-full justify-center items-center p-5 text-lg font-bold">
         <div className="flex justify-start items-center w-1/3">
           <div

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -14,7 +14,17 @@ import { HeaderRow, DataRow } from "@/components";
 import { useFetch, useMutation } from "@/hook";
 import { get, post } from "@/api";
 import "@/api/client/axiosInterceptors";
-import { Calendar, X, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
+import {
+  Calendar,
+  X,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  CreditCard,
+  Banknote,
+  // Check,
+  // CheckCheck,
+} from "lucide-react";
 
 // interface FormValues {
 //   item: string;
@@ -53,6 +63,7 @@ export default function Home(): ReactElement {
 
   const [isDateSlideOpen, setDateSlideOpen] = useState<boolean>(false);
   const [isHeaderActive, setHeaderActive] = useState<boolean>(false);
+  const [isComplexPayment, setComplexPayment] = useState<boolean>(false);
   /** POST 임시 상태 관리 */
   // const [, setIsResponse] = useState<LedgerRequire | null>(null);
   /** 폼 상태 관리 && 데이터 */
@@ -157,7 +168,44 @@ export default function Home(): ReactElement {
     // 여기서 h-screen은 매번 기입을 해야하는건가?
     <div className="h-screen flex flex-col items-center justify-center">
       <div className="flex w-full justify-center items-center p-5 text-lg font-bold">
-        <div className="flex justify-end items-center w-1/3" />
+        <div className="flex justify-start items-center w-1/3">
+          <div
+            className={`relative flex justify-center items-center w-11 h-6 transition-colors duration-200 ${
+              isComplexPayment ? "bg-blue-200" : "bg-gray-200"
+            } rounded-full`}
+            onClick={() => {
+              setComplexPayment((prev) => !prev);
+              setHeaderActive(true);
+            }}
+          >
+            <span
+              className={`absolute left-0 w-4 h-4 rounded-full transform transition-transform duration-400 ease-in-out ${
+                isComplexPayment
+                  ? "translate-x-6 bg-blue-400"
+                  : "translate-x-1 bg-white"
+              } transition-colors`}
+            />
+          </div>
+
+          {/* <span className="flex justify-center items-center ml-2 relative w-7 h-5 text-green-500 text-sm">
+            <div
+              className={`flex justify-center items-center absolute inset-0 transition-opacity duration-200 ease-in-out ${
+                isComplexPayment ? "opacity-100" : "opacity-0"
+              }`}
+            >
+              // <CheckCheck className="w-4 h-4" strokeWidth={3} />
+              단일
+            </div>
+            <div
+              className={`flex justify-center items-center absolute inset-0 transition-opacity duration-200 ease-in-out ${
+                isComplexPayment ? "opacity-0" : "opacity-100"
+              }`}
+            >
+              // <Check className="w-4 h-4" strokeWidth={3} />
+              복합
+            </div>
+          </span> */}
+        </div>
         <span className="flex justify-center items-center w-1/3">{today}</span>
         <div className="flex justify-end items-center w-1/3">
           <span
@@ -169,16 +217,16 @@ export default function Home(): ReactElement {
         </div>
       </div>
       <div
-        className={`flex items-center justify-center w-full transition-all duration-300 ease-in-out
+        className={`flex items-center justify-center w-full transition-all duration-500 ease-in-out
           ${
             isHeaderActive
-              ? "max-h-0 opacity-0 transform scale-y-0 origin-top p-0"
-              : "max-h-[500px] opacity-100 transform scale-y-100 origin-top p-2"
+              ? "max-h-[500px] opacity-100 transform scale-y-100 origin-top p-2"
+              : "max-h-0 opacity-0 transform scale-y-0 origin-top p-0"
           }
         }`}
       >
         <form
-          className="flex flex-col items-center justify-center w-full"
+          className="flex flex-col items-center justify-center w-full gap-2"
           onSubmit={handleSubmit(onSubmit)}
         >
           <div className="flex flex-col justify-center items-center gap-2 w-11/12">
@@ -274,6 +322,32 @@ export default function Home(): ReactElement {
                     {errors.costPrice.message}
                   </span>
                 )}
+              </div>
+            </div>
+          </div>
+          <div
+            className={`flex flex-col justify-center items-center w-11/12 transition-all duration-500 ease-in-out ${
+              isComplexPayment
+                ? "max-h-[500px] opacity-100 transform scale-y-100 origin-top"
+                : "max-h-0 opacity-0 transform scale-y-0 origin-top p-0"
+            }`}
+          >
+            <div className="flex flex-col justify-center items-center gap-1 w-full">
+              <div className="flex justify-center items-center w-full gap-1">
+                <CreditCard strokeWidth={2} className="text-blue-500" />
+                <span className="flex w-1/3">카드</span>
+                <input
+                  type="text"
+                  className="w-full p-2 border-1 border-gray-400 rounded"
+                />
+              </div>
+              <div className="flex justify-center items-center w-full gap-1 ">
+                <Banknote strokeWidth={2} className="text-green-500" />
+                <span className="flex w-1/3">현금</span>
+                <input
+                  type="text"
+                  className="w-full p-2 border-1 border-gray-400 rounded"
+                />
               </div>
             </div>
           </div>

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -53,6 +53,17 @@ export default function Home(): ReactElement {
   );
 
   const {
+    isData: paymentData,
+    isLoading: paymentLoading,
+    isError: paymentError,
+    fetchData: paymentFetchData,
+    // 해당 get의 타입이 명시적이 않다.
+  } = useFetch<PaymentModel[]>(
+    () => get<PaymentDataResponse>("/api/payment/get"),
+    true
+  );
+
+  const {
     isData: postData,
     isLoading: postLoading,
     isError: postError,
@@ -86,6 +97,7 @@ export default function Home(): ReactElement {
   const handleActive = ({
     handle,
   }: {
+    // 해당 Dispatch는 어떤 역할인가?
     handle: Dispatch<SetStateAction<boolean>>;
   }): void => {
     handle((prev) => !prev);
@@ -115,6 +127,7 @@ export default function Home(): ReactElement {
       // const result = await post("api/ledger/post", payload);
       await postMutate(payload);
       await fetchData();
+      await paymentFetchData();
       // if (result !== undefined) {
       //   setIsResponse(result);
       // }
@@ -128,7 +141,7 @@ export default function Home(): ReactElement {
     }
   };
 
-  /** API GET state 확인 */
+  /** ledger API GET state 확인 */
   useEffect(() => {
     console.log(todayUTC);
     if (getLoading) {
@@ -150,6 +163,21 @@ export default function Home(): ReactElement {
       console.log(getError);
     }
   }, [getData, getLoading, getError]);
+
+  /** payment API GET state 확인 */
+  useEffect(() => {
+    console.log(todayUTC);
+    if (paymentLoading) {
+      console.log("Loading...");
+    }
+    if (paymentData) {
+      console.log(paymentData);
+      // console.log(typeof paymentData);
+    }
+    if (paymentError) {
+      console.log(paymentError);
+    }
+  }, [paymentData, paymentLoading, paymentError]);
 
   /** API POST state 확인 */
   useEffect(() => {
@@ -363,11 +391,16 @@ export default function Home(): ReactElement {
         </form>
       </div>
       <div className="py-2">
-        <button onClick={() => handleActive({ handle: setHeaderActive })}>
+        <button
+          onClick={() => {
+            handleActive({ handle: setHeaderActive });
+            setComplexPayment(false);
+          }}
+        >
           {isHeaderActive ? (
-            <ChevronDown className="w-5 h-5" />
-          ) : (
             <ChevronUp className="w-5 h-5" />
+          ) : (
+            <ChevronDown className="w-5 h-5" />
           )}
         </button>
       </div>
@@ -385,12 +418,15 @@ export default function Home(): ReactElement {
             </div>
           ) : (
             getData &&
+            paymentData &&
             getData
               .filter(
                 (el) =>
                   String(el.createdAt).split("T")[0] === todayUTC.split("T")[0]
               )
-              .map((item) => <DataRow key={item.id} data={item} />)
+              .map((item) => (
+                <DataRow key={item.id} data={item} payment={paymentData} />
+              ))
           )}
           {/* {getData &&
             getData.map((item) => <DataRow key={item.id} data={item} />)} */}

--- a/client/src/app/test/test.ts
+++ b/client/src/app/test/test.ts
@@ -1,0 +1,19 @@
+// new Map을 사용해서 코드 간결화 필요.
+// const testPayment = async (): Promise<void> => {
+//   const payload: PaymentRequire[] = [
+//     {
+//       ledgerId: 50,
+//       type: "card",
+//       price: 9000,
+//       profit: 6300,
+//     },
+//     {
+//       ledgerId: 50,
+//       type: "cash",
+//       price: 9000,
+//       profit: 6300,
+//     },
+//   ];
+//   const result = await paymentPostMutate(payload);
+//   console.log("🎯result", result);
+// };

--- a/client/src/components/ui/DataRow.tsx
+++ b/client/src/components/ui/DataRow.tsx
@@ -1,10 +1,23 @@
 import { useState } from "react";
-import { LedgerModel } from "@/types";
+import { LedgerModel, PaymentModel } from "@/types";
 import { splitData, formatCurrencyData } from "@/utils";
 
-const DataRow = ({ data }: { data: LedgerModel }): React.ReactElement => {
+const DataRow = ({
+  data,
+  payment,
+}: {
+  data: LedgerModel;
+  payment: PaymentModel[];
+}): React.ReactElement => {
   const [isButtonActive, setButtonActive] = useState<boolean>(true);
 
+  const paymentForThisRow = Array.isArray(payment)
+    ? payment.filter((el) => el.ledgerId === data.id)
+    : [];
+  const cardPayment = paymentForThisRow.find((el) => el.type === "card");
+  const cashPayment = paymentForThisRow.find((el) => el.type === "cash");
+  console.log(cardPayment);
+  console.log(cashPayment);
   return (
     <>
       <div
@@ -25,17 +38,23 @@ const DataRow = ({ data }: { data: LedgerModel }): React.ReactElement => {
           <div className="w-7/100 py-3 px-0 text-center">{data.count}</div>
           <div className="flex flex-col w-26/100 py-3 px-2 text-right">
             {formatCurrencyData(data.salePrice, "ko-KR")}
-            <div className="flex flex-col justify-between text-xs text-gray-600">
-              <span>카드 16,000</span>
-              <span>현금 16,000</span>
-            </div>
+            {paymentForThisRow.length > 0 && (
+              <div className="flex flex-col justify-between text-xs text-gray-600">
+                <span>
+                  카드 {formatCurrencyData(cardPayment?.price ?? 0, "ko-KR")}
+                </span>
+                <span>
+                  현금 {formatCurrencyData(cashPayment?.price ?? 0, "ko-KR")}
+                </span>
+              </div>
+            )}
           </div>
           <div className="flex flex-col w-26/100 py-3 px-1 text-right">
             {formatCurrencyData(data.costPrice, "ko-KR")}
-            <div className="flex flex-col justify-between text-xs text-gray-600">
+            {/* <div className="flex flex-col justify-between text-xs text-gray-600">
               <span>카드 16,000</span>
               <span>현금 16,000</span>
-            </div>
+            </div> */}
           </div>
           <div className="flex flex-col w-23/100 py-3 px-1 text-right text-green-600 font-medium">
             {formatCurrencyData(data.profit, "ko-KR")}

--- a/client/src/components/ui/DataRow.tsx
+++ b/client/src/components/ui/DataRow.tsx
@@ -16,8 +16,8 @@ const DataRow = ({
     : [];
   const cardPayment = paymentForThisRow.find((el) => el.type === "card");
   const cashPayment = paymentForThisRow.find((el) => el.type === "cash");
-  console.log(cardPayment);
-  console.log(cashPayment);
+  // console.log(cardPayment);
+  // console.log(cashPayment);
   return (
     <>
       <div

--- a/client/src/pages/api/payment/get.ts
+++ b/client/src/pages/api/payment/get.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { axiosInstanceServer } from "@/api";
+//import { corsMiddleware } from "@/utils/cors";
+
+const get = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  //await corsMiddleware(req, res);
+
+  try {
+    const response = await axiosInstanceServer.get("/payment");
+    // const { data } = await axiosInstanceServer.get("/ledger");
+    res.status(200).json(response.data);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: "An unknown error occurred" });
+  }
+};
+
+export default get;

--- a/client/src/pages/api/payment/post.ts
+++ b/client/src/pages/api/payment/post.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { axiosInstanceServer } from "@/api";
+// import { corsMiddleware } from "@/utils/cors";
+
+const post = async <T>(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<T> => {
+  // await corsMiddleware(req, res);
+
+  try {
+    console.log("check response", req.body);
+    const response = await axiosInstanceServer.post<T>(`/payment`, req.body);
+    res.status(200).json(response.data);
+    return response.data;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error(error);
+    } else {
+      console.error("예외 타입 Error", String(error));
+      throw new Error("알 수 없는 에러");
+    }
+  }
+  // undefined를 반환하지 않는 경우 에러 발생 또는 undeinfed를 명시적으로 반환하는 것이 좋음.
+  throw new Error("post 함수에서 반환되지 않았습니다.");
+};
+export default post;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./api";
 export * from "./error";
 export * from "./ledger";
+export * from "./payment";

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,3 +1,11 @@
+/** 공통 타입 */
+import { LedgerRequire } from "./ledger";
+
+export interface FormRequire extends LedgerRequire {
+  cardPrice?: number;
+  cashPrice?: number;
+}
+
 export * from "./api";
 export * from "./error";
 export * from "./ledger";

--- a/client/src/types/payment.ts
+++ b/client/src/types/payment.ts
@@ -1,0 +1,17 @@
+export interface PaymentRequire {
+  type: boolean;
+  price: number;
+  profit: number;
+  updateAt: string;
+  createdAt: string;
+}
+
+export interface PaymentModel extends PaymentRequire {
+  id: number;
+  ledgerId: number;
+}
+
+export interface PaymentDataResponse {
+  data: PaymentModel[];
+  error: null | string;
+}

--- a/client/src/types/payment.ts
+++ b/client/src/types/payment.ts
@@ -1,14 +1,14 @@
 export interface PaymentRequire {
-  type: boolean;
+  ledgerId: number;
+  type: string;
   price: number;
   profit: number;
-  updateAt: string;
-  createdAt: string;
 }
 
 export interface PaymentModel extends PaymentRequire {
   id: number;
-  ledgerId: number;
+  updateAt: string;
+  createdAt: string;
 }
 
 export interface PaymentDataResponse {

--- a/client/src/utils/splitData.ts
+++ b/client/src/utils/splitData.ts
@@ -1,5 +1,5 @@
 export default function splitData(data: string): string[] {
   const splitData = data.split(",");
-  console.log(splitData);
+  // console.log(splitData);
   return splitData;
 }


### PR DESCRIPTION
- close: #31 
 
# Goal
- [x] 다중 결제 payment 테이블 GET API를 연동한다.
- [x] 다중 결제 payment 테이블 POST API를 연동한다.
  - [x] axiosInterceptor transformers의 반환 값을 수정한다. 
- [x] onSubmit에서 다중으로 post 할 수 있는 방법을 고안한다.
# QA 반영
- [x] 상단에 복합 결제 토글을 구현한다.
- [x] 상품 등록 하단에 다중 결제 input interface가 슬라이드로 등록하게 구현한다.

---

# axiosInterceptor transformers 수정

transformers 유틸리티 함수는 백엔드와 프론트엔드의 변수명을 맞추기 위해서 존재하는 함수이다. 단 해당 함수들은 직렬 기반 객체 형태로 요청 했을 시에 처리하는 코드로 구현이 되어 있다. 하지만, payment 테이블의 API가 추가 되면서 요청시 객체 기반 배열로 여러 객체를 보내는 병렬 형식으로 API가 구현되면서 재귀함수를 사용해서 transformers 코드를 수정 했다. 자세한 내용은 기술 블로그에 작성 했다.
[axiosInterceptor transformers](https://velog.io/@4bee/axiosInterceptor-transformers)

# QA적용

|QA 반영 전| QA 반영 후|
|---|---|
|<img width="369" alt="image" src="https://github.com/user-attachments/assets/846bc254-3634-4623-a0c3-18dcbc12cfa7" />|<img width="366" alt="image" src="https://github.com/user-attachments/assets/01ab8b94-5055-48ee-b4ef-011d12eac493" />|

